### PR TITLE
Cover EReader.processMsg uncovered cases BOND_CONTRACT_DATA, ACCT_DOWNLOAD_END and EXECUTION_DATA_END

### DIFF
--- a/1_tullibee/additionalvalues/gentests_recom/TestValues.java
+++ b/1_tullibee/additionalvalues/gentests_recom/TestValues.java
@@ -6,9 +6,47 @@ import com.ib.client.*;
 
 public class TestValues {
 
-    public static DataInputStream disOne() {
-        return new DataInputStream(new StringBufferInputStream("1\0"));
+    public static DataInputStream disOneOne() {
+		//BOND_CONTRACT_DATA
+		String str = "kkeaemen";
+		Double dd = 7.77;
+		int interino = 1;
+		String action = "18";
+		String input = action + "\0" + interino + "\0"+ str +"\0" + str + "\0" + 
+		str +"\0" + dd + "\0"+ str +"\0" + str + "\0"+ str +"\0" +
+		str + "\0"+ str +"\0" + interino + "\0"+ 
+		interino +"\0" + interino + "\0"+ 
+		str +"\0" +  str +"\0" + str + "\0"+ str +"\0" +
+		str +"\0" + interino + "\0"+ dd +"\0" +  str +"\0" + str + "\0";
+        return new DataInputStream(new StringBufferInputStream(input));
+	}
+
+	public static DataInputStream disOneTwo() {
+		//ACCT_DOWNLOAD_END
+		String action = "54";
+		String interino = "1";
+		String textinput = "berg";
+		String input =  action + "\0"+ interino + "\0" + textinput+ "\0";
+        return new DataInputStream(new StringBufferInputStream(input));
+	}
+
+	public static DataInputStream disOneThree() {
+		//EXECUTION_DATA_END
+		String action = "55";
+		String interino = "1";
+		String input =  action + "\0"+ interino +"\0" + interino+ "\0";
+        return new DataInputStream(new StringBufferInputStream(input));
+	}
+	public static void eReaderOne() {
+         new com.ib.client.EReader(disOneOne(), eWrapperOne(), 44).run();
+	}
+	public static void eReaderTwo() {
+         new com.ib.client.EReader(disOneTwo(), eWrapperOne(), 44).run();
+	}
+	public static void eReaderThree() {
+         new com.ib.client.EReader(disOneThree(), eWrapperOne(), 44).run();
     }
+	
 
     
     // public static DataInputStream disOne() {

--- a/1_tullibee/targets.txt
+++ b/1_tullibee/targets.txt
@@ -37,3 +37,78 @@ every call to processMsg(1) raises java.io.Exception captured at EReader.run:102
         String all = "1" + "\0" + "2" + "\0" + "3" + "\0" + "4" + "\0" + "2.97" + "\0";
         return new DataInputStream(new StringBufferInputStream(all));
       }
+
+com.ib.client.EReader, processMsg, 629, "int version = readInt();", Receive all values and execute the eWrapper function, case not being reached
+input stream with string that covers the case,
+      public static DataInputStream disOneOne() {
+		String str = "kkeaemen";
+		Double dd = 7.77;
+		int interino = 1;
+		String input = "18" + "\0" + interino + "\0"+ str +"\0" + str + "\0" + 
+		str +"\0" + dd + "\0"+ str +"\0" + str + "\0"+ str +"\0" +
+		str + "\0"+ str +"\0" + interino + "\0"+ 
+		interino +"\0" + interino + "\0"+ 
+		str +"\0" +  str +"\0" + str + "\0"+ str +"\0" +
+		str +"\0" + interino + "\0"+ dd +"\0" +  str +"\0" + str + "\0";
+        return new DataInputStream(new StringBufferInputStream(input));
+	}
+
+com.ib.client.EReader, processMsg, 856, "/* int version = */readInt();", Reads values and execute eWrapper function  ,case not being reached,
+input stream with string that covers the case.,
+      public static DataInputStream disOneTwo() {
+		String action = "54";
+		String interino = "1";
+		String textinput = "berg";
+		String input =  action + "\0"+ interino + "\0" + textinput+ "\0";
+        return new DataInputStream(new StringBufferInputStream(input));
+	}
+
+
+com.ib.client.EReader, processMsg, 861, "/* int version = */readInt();", Reads values and execute eWrapper function ,case read is never executed,
+input stream with string that covers the case 
+	public static DataInputStream disOneThree() {
+		String action = "55";
+		String interino = "1";
+		String input =  action + "\0"+ interino +"\0" + interino+ "\0";
+        return new DataInputStream(new StringBufferInputStream(input));
+	}
+
+com.ib.client.Ereader, processMsg, 858, "eWrapper().accountDownloadEnd(accountName);", NPE throw, eWrapper object sent null,
+instantiated eWrapper with matching input call
+      public static EReader eReaderOne() {
+         return new com.ib.client.EReader(disOneOne(), eWrapperOne(), 44);
+	}
+
+com.ib.client.Ereader, processMsg, 864, "eWrapper().execDetailsEnd(reqId);", NPE throw at the processMsg call thus not reaching case read, eWrapper object sent null,
+instantiated eWrapper with matching input call
+      public static EReader eReaderTwo() {
+         return new com.ib.client.EReader(disOneTwo(), eWrapperOne(), 44);
+	}
+
+com.ib.client.Ereader, processMsg, 668, "eWrapper().bondContractDetails(reqId, contract);", NPE throw sometimes because of tests indertemination, eWrapper object sent null,
+instantiated eWrapper with matching input call
+      public static EReader eReaderThree() {
+         return new com.ib.client.EReader(disOneThree(), eWrapperOne(), 44);
+	}
+
+com.ib.client.Ereader, processMsg, 858, "eWrapper().accountDownloadEnd(accountName);", method run sometimes is not being called in test generation,.run() no being called,
+forced the EReader instance to call run() in tests
+      public static void eReaderOne() {
+          new com.ib.client.EReader(disOneOne(), eWrapperOne(), 44).run();
+	}
+
+com.ib.client.Ereader, processMsg, 864, "eWrapper().execDetailsEnd(reqId);", method run sometimes is not being called in test generation, .run() no being called,
+forced the EReader instance to call run() in tests
+      public static void eReaderTwo() {
+          new com.ib.client.EReader(disOneTwo(), eWrapperOne(), 44).run();
+	}
+
+com.ib.client.Ereader, processMsg, 668, "eWrapper().bondContractDetails(reqId, contract);", method run sometimes is not being called in test generation,.run() no being called,
+forced the EReader instance to call run() in tests
+      public static void eReaderThree() {
+          new com.ib.client.EReader(disOneThree(), eWrapperOne(), 44).run();
+	}
+
+
+
+


### PR DESCRIPTION
Added new data input streams and EReader instantiation to cover EReader.processMsg method uncovered cases.  